### PR TITLE
Deprecate `http_auth=` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,5 +67,4 @@ options:
                         Number of documents to process at once (default: 1000)
   -i INDEX, --index INDEX
                         Specify the Elasticsearch index
-
 ```

--- a/es-exporter.py
+++ b/es-exporter.py
@@ -83,7 +83,7 @@ async def main(query_file: str, post_process: str, output_file: str, full: bool,
 
     es = AsyncElasticsearch(
         hosts=[NodeConfig(scheme=scheme, host=host, port=port)],
-        http_auth=(username, password) if username and password else None,
+        basic_auth=(username, password) if username and password else None,
         ca_certs=ca_cert if ca_cert is not None else DEFAULT
     )
 

--- a/es-importer.py
+++ b/es-importer.py
@@ -141,7 +141,7 @@ async def main(file_path: str, file_encoding: str, index: str, scheme: str, host
 
     es = AsyncElasticsearch(
         hosts=[NodeConfig(scheme=scheme, host=host, port=port)],
-        http_auth=(username, password) if username and password else None,
+        basic_auth=(username, password) if username and password else None,
         ca_certs=ca_cert if ca_cert is not None else DEFAULT
     )
     await process_file(file_path, file_encoding, index, es, generate_action, id_field, pipeline, chunk_size, dry_run)


### PR DESCRIPTION
This PR replaces the deprecated `http_auth=` argument with `basic_auth=`. Closes #8.
